### PR TITLE
Initialize FlType/iFlType in the Write*2D routines of m_iomod.f90

### DIFF
--- a/src/IOMODS/m_iomod.f90
+++ b/src/IOMODS/m_iomod.f90
@@ -2236,6 +2236,19 @@ CONTAINS
     HeaderData = .FALSE.
     IF(PRESENT(WriteDataInHeader)) HeaderData = WriteDataInHeader
 
+    ! Default before the optional-argument guard below. FlType goes into the
+    ! '#DF#' header line and iFlType selects the data format, but both were only
+    ! ever assigned inside that guard, which has no ELSE. A caller omitting
+    ! FileType -- e.g. Write2D('gg.bin',..) in FMS/fmstot.f90 -- therefore read
+    ! both uninitialized. Depending on what was left on the stack that meant
+    ! garbage in the header, data silently written in PAD instead of TXT (Read2D
+    ! always defaults to TXT and never parses '#DF#' back, so the round trip
+    ! fails), or -- if iFlType matched neither itxt nor ipad -- no data written
+    ! at all behind a valid-looking header.
+    ! TXT is the right default: it matches iFileTypeDefault, which every Read*2D
+    ! routine already uses when FileType is absent.
+    FlType = 'TXT'
+    iFlType = itxt
     IF(PRESENT(FileType)) THEN
        FlType = TRIM(ADJUSTL(FileType))
        CALL Upper(FlType)
@@ -2313,6 +2326,9 @@ CONTAINS
     HeaderData = .FALSE.
     IF(PRESENT(WriteDataInHeader)) HeaderData = WriteDataInHeader
     
+    ! Default before the guard below; see WriteInt2D for why this is needed.
+    FlType = 'TXT'
+    iFlType = itxt
     IF(PRESENT(FileType)) THEN
        FlType = TRIM(ADJUSTL(FileType))
        CALL Upper(FlType)
@@ -2393,6 +2409,8 @@ CONTAINS
     IF(PRESENT(WriteDataInHeader)) HeaderData = WriteDataInHeader
 
     iFlType = 1
+    ! Default before the guard below; see WriteInt2D for why this is needed.
+    FlType = 'TXT'
     IF(PRESENT(FileType)) THEN
        FlType = TRIM(ADJUSTL(FileType))
        CALL Upper(FlType)
@@ -2473,6 +2491,8 @@ CONTAINS
     IF(PRESENT(WriteDataInHeader)) HeaderData = WriteDataInHeader
     
     iFlType = itxt
+    ! Default before the guard below; see WriteInt2D for why this is needed.
+    FlType = 'TXT'
     IF(PRESENT(FileType)) THEN
        FlType = TRIM(ADJUSTL(FileType))
        CALL Upper(FlType)
@@ -2552,6 +2572,9 @@ CONTAINS
     HeaderData = .FALSE.
     IF(PRESENT(WriteDataInHeader)) HeaderData = WriteDataInHeader
     
+    ! Default before the guard below; see WriteInt2D for why this is needed.
+    FlType = 'TXT'
+    iFlType = itxt
     IF(PRESENT(FileType)) THEN
        FlType = TRIM(ADJUSTL(FileType))
        CALL Upper(FlType)


### PR DESCRIPTION
Fixes #34.

Five `Write*2D` routines in `src/IOMODS/m_iomod.f90` assigned `FlType` and `iFlType`
only inside `IF(PRESENT(FileType))`, which has no `ELSE` branch and no preceding
default — so a caller omitting the optional `FileType` argument read both
uninitialized. `FMS/fmstot.f90:420` (`Write2D('gg.bin', ...)`) is such a caller.

This adds the default before the guard in all five:

```fortran
FlType = 'TXT'
iFlType = itxt
IF(PRESENT(FileType)) THEN
   ...
```

`WriteDouble2D` and `WriteComplex2D` already had the `iFlType` default and get only
`FlType`. Full rationale is in issue #34; the short version is that the symptom
ranges from a varying `#DF#` header byte to data silently written in PAD while
`Read2D` reads it as TXT, to no data written at all.

**Why TXT.** It matches `iFileTypeDefault` (`= 1`), which all six `Read*2D` routines
already use when `FileType` is absent. Writer and reader now agree.

**Not changed.** `WriteString2D` has no `PRESENT(FileType)` guard, writes no `#DF#`
line, and already sets `iFlType`. The six `Read*2D` routines all pre-set
`iFlType = iFileTypeDefault` and touch `FlType` only inside the guard.

## Verification

- The round-trip reproducer in #34 (`Write2D` then `Read2D`, neither passing
  `FileType`) fails on `master` at `-O0`, `-O2` and `-O3`, and passes with this
  change.
- With the fix, output from a call omitting `FileType` is byte-identical to one
  passing `FileType='TXT'`.
- `gfortran -O2 -Wall` on the file: **3 `'ifltype' may be used uninitialized`
  warnings before, 0 after.**
- The file compiles clean under both gfortran 11.5.0 and ifort 2021.6.0.
- Ran the full EXAFS chain (`rdinp` → `ff2x`) on two cases before and after, under
  both compilers: `xmu.dat` and `chi.dat` are byte-identical. `#DF#` is never parsed
  back, so no numerical output changes.

## One note for reviewers

The fix **does** change `gg.bin`'s header bytes, so a pre-fix binary and a post-fix
one no longer produce byte-identical `gg.bin` files. If you keep any byte-level
reference outputs that include `gg.bin`, they need regenerating. Spectrum files are
unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
